### PR TITLE
Harrylui1995

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: HKUST-OCTAD-LAB/AirTrafficSim-data
-        ref: 'main'
         ssh-key: ${{ secrets.SSH_KEY }}
         path: AirTrafficSim-data
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: HKUST-OCTAD-LAB/AirTrafficSim-data
+        ref: 'main'
         ssh-key: ${{ secrets.SSH_KEY }}
         path: AirTrafficSim-data
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ git clone https://github.com/HKUST-OCTAD-LAB/AirTrafficSim.git
 conda env create -f environment.yml
 
 cd AirTrafficSim
-conda activate airtrafficsim
+conda activate airtrafficsim_develop
 <!-- With UI -->
 python -m airtrafficsim
 <!-- Without UI -->

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: airtrafficsim
+name: airtrafficsim_develop
 channels:
   - conda-forge
   - defaults


### PR DESCRIPTION
Since the conda AirTrafficSim, and git clone AirTrafficSim for developer share the same environment name, which creates conflict. I change the environment name in environment.yml and contribution. md to "airtrafficsim_develop".